### PR TITLE
Fix Cryptol number syntax, add module keywords.

### DIFF
--- a/syntax/cryptol.vim
+++ b/syntax/cryptol.vim
@@ -40,7 +40,7 @@ syn region  cryString		start=+"+  skip=+\\\\\|\\"+  end=+"+  contains=crySpecial
 syn region  cryString		start=+``+  skip=+\\\\\|\\"+  end=+``+  contains=hsSpecialChar
 syn match   cryCharacter		"[^a-zA-Z0-9_']'\([^\\]\|\\[^']\+\|\\'\)'"lc=1 contains=crySpecialChar,crySpecialCharError
 syn match   cryCharacter		"^'\([^\\]\|\\[^']\+\|\\'\)'" contains=crySpecialChar,crySpecialCharError
-syn match   cryNumber		"\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>"
+syn match   cryNumber		"\<[0-9]\+\>\|\<0[b][01]\+\>\|\<0[x][0-9a-fA-F]\+\>\|\<0[o][0-7]\+\>"
 
 " Keyword definitions.
 
@@ -59,6 +59,7 @@ syn keyword cryPrimitive        error parity lg2 pmod pdiv pmult format
 syn keyword cryPrimitive        join split groupBy take drop min max negate reverse
 syn keyword cryPrimitive        project tail width
 syn keyword cryPrimitive        ASSERT
+syn keyword cryPrimitive        module import private
 
 " Comments
 syn match   cryLineComment      "//.*"


### PR DESCRIPTION
Two minor changes. Firstly, the regex for Cryptol numbers with base specifiers (0x01, 0b0101 etc) need to use lower-case letters. Secondly, this adds the new module system keywords added in Cryptol 2.
